### PR TITLE
hound.vim vertical split option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ nnoremap <leader>a :Hound<space>
 ```
 for quick access.
 
+If you want a vertical split instead of a new window:
+```vimscript
+leg g:hound_vertical_split = 1
+```
+
 This is a beta release. Please let me know of any bugs! There will be bugs! More docs and features and options to come.
 
 Doge

--- a/plugin/hound.vim
+++ b/plugin/hound.vim
@@ -15,6 +15,9 @@ if !exists('g:hound_verbose')
     let g:hound_verbose=1
 endif
 
+if !exists('g:hound_vertical_split')
+    let g:hound_vertical_split=0
+endif
 
 function! hound#encodeUrl(string) abort
     let mask = "[ \\]'\!\#\$&(),\*\+\/:;=?@\[]"
@@ -82,9 +85,17 @@ function! Hound(...) abort
             echo "Nothing for you, Dawg"
         else
             if (bufwinnr("__Hound_Results__") > 0)
-                :edit __Hound_Results__
+                if g:hound_vertical_split
+                    :ve __Hound_Results__
+                else
+                    :edit __Hound_Results__
+                endif
             else
-                :enew "__Hound_Results__"
+                if g:hound_vertical_split
+                    :vnew "__Hound_Results__"
+                else
+                    :enew "__Hound_Results__"
+                endif
             endif
 
             normal! ggdG

--- a/plugin/hound.vim
+++ b/plugin/hound.vim
@@ -86,7 +86,7 @@ function! Hound(...) abort
         else
             if (bufwinnr("__Hound_Results__") > 0)
                 if g:hound_vertical_split
-                    :ve __Hound_Results__
+                    :vs __Hound_Results__
                 else
                     :edit __Hound_Results__
                 endif


### PR DESCRIPTION
This is pretty hacky, sorry!

Allows a user to specify if they want the hound buffer to appear in a vertical split window.  I've been using it for a while, and I like how it feels.
