### PR TITLE
Quickfix window support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Introduces the
 
 command, which takes a string and asks a hound server: "like hey what's up with this string?" and presents the results in a scratch buffer.
 
+You can also get the results in a quickfix window by running
+```
+QHound <searchterm>
+```
+
 hound.vim assumes you have a server running on localhost at port 6080. If you want to hit somewhere else you can redefine either in your .vimrc:
 
 ```vimscript
@@ -35,6 +40,15 @@ You can also limit which repos you search through with (case insensitive) comma 
 ```vimscript
 let g:hound_repos = "arepo,anotherrepo,anynumberofrepos"
 ```
+
+You can tell hound.vim where your repositories live, by specifying a lower case
+dictionary like so:
+```vimscript
+ let g:hound_repo_paths = {
+    \'arepo': '/path/to/arepo',
+    \'anotherrepo': '~/path/to/anotherrepo',}
+```
+
 To ignore case in searches by default:
 
 ```vimscript

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ command, which takes a string and asks a hound server: "like hey what's up with 
 
 You can also get the results in a quickfix window by running
 ```
-QHound <searchterm>
+HoundQF <searchterm>
 ```
 
 hound.vim assumes you have a server running on localhost at port 6080. If you want to hit somewhere else you can redefine either in your .vimrc:

--- a/doc/hound.txt
+++ b/doc/hound.txt
@@ -1,1 +1,87 @@
-I'll put docs here, I promise.
+*hound.txt* talk to Etsy's Hound trigram search.
+
+ _   _                       _  ~
+| | | | ___  _   _ _ __   __| | ~
+| |_| |/ _ \| | | | '_ \ / _` | ~
+|  _  | (_) | |_| | | | | (_| | ~
+|_| |_|\___/ \__,_|_| |_|\__,_| ~
+
+Lightning fast code searching made easy
+
+====================================================================
+CONTENTS                                            *HoundContents*
+
+    1. Usage ................ |HoundUsage|
+    2. Configuration ........ |HoundConfiguration|
+    3. Mappings ............. |HoundMappings|
+    4. Contributing ......... |HoundContributing|
+
+==============================================================================
+1. Usage                                                          *HoundUsage*
+
+The :Hound command  takes a string and asks a hound server:
+"like hey what's up with this string?" and presents the
+results in a temporary file.
+
+Use it like this: >
+
+    :Hound foo
+
+Or like this: >
+
+    :Hound foo bar baz
+
+You can also get the results in a quickfix window by running: >
+
+    :QHound foo
+
+QFEnter and vim-unimpaired are useful plugins that will make
+quickfix windows easier to work with.
+
+=============================================================================
+2. Configuration                                         *HoundConfiguration*
+
+hound.vim assumes you have a server running on localhost at port 6080.
+If you want to hit somewhere else you can redefine either in your .vimrc:
+
+ let g:hound_base_url = "arbitrary.url.com"
+ let g:hound_port = "6081"
+
+You can also limit which repos you search through with (case insensitive)
+comma separated strings:
+
+ let g:hound_repos = "arepo,anotherrepo,anynumberofrepos"
+
+This property is inferred if you specify g:hound_repo_paths.
+
+You can tell hound.vim where your repositories live, by specifying a lower case
+dictionary like so:
+
+ let g:hound_repo_paths = {
+    \'arepo': '/path/to/arepo',
+    \'anotherrepo': '~/path/to/anotherrepo',}
+
+To ignore case in searches by default:
+
+ let g:hound_ignore_case = 1
+
+If you want to open Hound results in a vertical split
+
+ let g:hound_vertical_split = 1
+
+=============================================================================
+3. Mappings                                                   *HoundMappings*
+
+To search the token under your cursor you can do something like: >
+
+ nnoremap <C-h> :Hound<space><C-R><C-W>
+
+or
+
+ nnoremap <C-h> :QHound<space><C-R><C-W>
+
+=============================================================================
+4. Contributing                                           *HoundContributing*
+
+Please report issues, feature requests and pull requests to
+https://github.com/urthbound/hound.vim

--- a/doc/hound.txt
+++ b/doc/hound.txt
@@ -33,7 +33,7 @@ Or like this: >
 
 You can also get the results in a quickfix window by running: >
 
-    :QHound foo
+    :HoundQF foo
 
 QFEnter and vim-unimpaired are useful plugins that will make
 quickfix windows easier to work with.
@@ -78,7 +78,7 @@ To search the token under your cursor you can do something like: >
 
 or
 
- nnoremap <C-h> :QHound<space><C-R><C-W>
+ nnoremap <C-h> :HoundQF<space><C-R><C-W>
 
 =============================================================================
 4. Contributing                                           *HoundContributing*

--- a/plugin/hound.vim
+++ b/plugin/hound.vim
@@ -8,6 +8,13 @@ endif
 
 if !exists('g:hound_repos')
     let g:hound_repos="*"
+    if exists('g:hound_repo_paths')
+        let g:hound_repos = join(keys(g:hound_repo_paths), ",")
+    endif
+endif
+
+if !exists('g:hound_repo_paths')
+    let g:hound_repo_paths = {}
 endif
 
 if !exists('g:hound_verbose')
@@ -28,9 +35,17 @@ function! hound#encodeUrl(string) abort
     return substitute(a:string, mask, '\=printf("%%%x", char2nr(submatch(0)))', 'g')
 endfunction
 
-function! Hound(...) abort
+function! hound#buildWebUrl(query_string, clean_repos)
+    let sanitized_query_string = hound#encodeUrl(a:query_string)
 
-    let a:query_string = join(a:000)
+    return g:hound_base_url . ':' . g:hound_port
+                \. '?repos=' . a:clean_repos
+                \. '&i=' . g:hound_ignore_case
+                \. '&q=' . sanitized_query_string
+
+endfunction
+
+function! hound#fetchResults(query_string, clean_repos)
     let sanitized_query_string = hound#encodeUrl(a:query_string)
 
     let clean_repos = substitute(tolower(g:hound_repos), " ","","g")
@@ -38,48 +53,112 @@ function! Hound(...) abort
     let s:api_full_url = g:hound_base_url
                 \. ":" . g:hound_port
                 \. '/api/v1/search?'
-                \. '&repos=' . clean_repos
-                \. '&i=' . g:hound_ignore_case
-                \. '&q=' . sanitized_query_string
-
-    let s:web_full_url = g:hound_base_url . ':' . g:hound_port
-                \. '?repos=' . clean_repos
+                \. '&repos=' . a:clean_repos
                 \. '&i=' . g:hound_ignore_case
                 \. '&q=' . sanitized_query_string
 
     let s:curl_response=system('curl -s "'.s:api_full_url.'"')
 
     try
-        let s:response = webapi#json#decode(s:curl_response)
+        let response = webapi#json#decode(s:curl_response)
     catch
-        echoerr "Hound could not connect to " . g:hound_base_url . ":" . g:hound_port
+        throw "Hound could not connect to " . g:hound_base_url . ":" . g:hound_port
     endtry
 
-    if (has_key(s:response, 'Error'))
-        echoerr "Hound server says: " . s:response["Error"]
-        return
-    end
+    if (has_key(response, 'Error'))
+        throw "Hound server error: " . response["Error"]
+    endif
 
+    return response
+endfunction
+
+function! hound#getRepoBasePath(repo_name)
+    if !empty(g:hound_repo_paths) && has_key(g:hound_repo_paths, a:repo_name)
+        return fnamemodify(g:hound_repo_paths[a:repo_name], ":p")
+    endif
+    return ""
+endfunction
+
+function! QHound(...) abort
+    let query_string = join(a:000)
+
+    if empty('g:hound_repo_paths')
+        echo "You must set g:hound_repo_paths in your vimrc to use QHound"
+        return
+    endif
+
+    let clean_repos = substitute(tolower(join(keys(g:hound_repo_paths), ',')), " ","","g")
+
+    try
+        let response = hound#fetchResults(query_string, clean_repos)
+    catch
+        echoerr v:exception
+    endtry
+
+    let repos = []
+    for tuple in items(response["Results"])
+        let repos += [tuple[0]]
+    endfor
+
+    let qflist = []
+
+    for repo in repos
+        let repo_base_path = hound#getRepoBasePath(repo)
+
+        for file_match in response["Results"][repo]["Matches"]
+            for line_match in file_match['Matches']
+                let qfitem = {
+                    \'filename': repo_base_path . file_match["Filename"],
+                    \'lnum': line_match["LineNumber"],
+                    \'pattern': '',
+                    \'text': line_match["Line"], }
+                call add(qflist, qfitem)
+            endfor
+        endfor
+    endfor
+
+    if empty(qflist)
+        echo "Nothing for you, Dawg"
+    else
+        call setqflist(qflist)
+        copen
+    end
+endfunction
+
+function! Hound(...) abort
+
+    let query_string = join(a:000)
+    let clean_repos = substitute(tolower(g:hound_repos), " ","","g")
+
+    try
+        let response = hound#fetchResults(query_string, clean_repos)
+    catch
+        echoerr v:exception
+    endtry
+
+    let s:web_full_url = hound#buildWebUrl(query_string, clean_repos)
     let s:output = s:web_full_url
 
     let repos = []
-    for tuple in items(s:response["Results"])
+    for tuple in items(response["Results"])
         let repos += [tuple[0]]
     endfor
 
     for repo in repos
+        let repo_base_path = hound#getRepoBasePath(repo)
+
         let s:output .= "\n\nRepo: " . repo . "\n================================================================================\n"
-        for mymatch in s:response["Results"][repo]["Matches"]
-            for mymatch2 in mymatch["Matches"]
-                let s:output.="\n".mymatch["Filename"]
-                            \.":".mymatch2["LineNumber"]
+        for file_match in response["Results"][repo]["Matches"]
+            for line_match in file_match["Matches"]
+                let s:output.="\n".repo_base_path.file_match["Filename"]
+                            \.":".line_match["LineNumber"]
                             \."\n--------------------------------------------------------------------------------\n"
                 if g:hound_verbose
-                    let s:output.=join(mymatch2["Before"], "\n")
-                                \. "\n" . mymatch2["Line"] . "\n"
-                                \.join(mymatch2["After"], "\n")."\n"
+                    let s:output.=join(line_match["Before"], "\n")
+                                \. "\n" . line_match["Line"] . "\n"
+                                \.join(line_match["After"], "\n")."\n"
                 else
-                    let s:output.=substitute(mymatch2["Line"], '^\s*\(.\{-}\)\s*$', '\1', '') . "\n"
+                    let s:output.=substitute(line_match["Line"], '^\s*\(.\{-}\)\s*$', '\1', '') . "\n"
                 endif
                 let s:output.="\n"
             endfor
@@ -101,9 +180,9 @@ function! Hound(...) abort
         normal! gg
 
         if g:hound_ignore_case == 1
-            let l:query = '\c' . a:query_string
+            let l:query = '\c' . query_string
         else
-            let l:query = a:query_string
+            let l:query = query_string
         endif
         exec 'syntax match queryString "'.l:query.'"'
         highlight link queryString DiffAdd
@@ -115,3 +194,4 @@ function! Hound(...) abort
 endfunction
 
 command! -nargs=1 Hound call Hound(<f-args>)
+command! -nargs=1 QHound call QHound(<f-args>)

--- a/plugin/hound.vim
+++ b/plugin/hound.vim
@@ -79,11 +79,11 @@ function! hound#getRepoBasePath(repo_name)
     return ""
 endfunction
 
-function! QHound(...) abort
+function! HoundQF(...) abort
     let query_string = join(a:000)
 
     if empty('g:hound_repo_paths')
-        echo "You must set g:hound_repo_paths in your vimrc to use QHound"
+        echo "You must set g:hound_repo_paths in your vimrc to use HoundQF"
         return
     endif
 
@@ -194,4 +194,4 @@ function! Hound(...) abort
 endfunction
 
 command! -nargs=1 Hound call Hound(<f-args>)
-command! -nargs=1 QHound call QHound(<f-args>)
+command! -nargs=1 HoundQF call HoundQF(<f-args>)


### PR DESCRIPTION
This change adds a QHound command that puts Hound's results in a quickfix window.

The quickfix window is used by `:grep`, `:Ag` etc., and it makes it easy to jump between instances of a search result.

In order to make the quickfix window useful, I needed to add an additional config option `g:hound_repo_paths` to know where the repo's files were located on disk.

Let me know what you think!
