### PR TITLE
Add flag to preserve repo title case

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ dictionary like so:
     \'anotherrepo': '~/path/to/anotherrepo',}
 ```
 
+If your repos have uppercase letters, please specify them with capitals in `g:hound_repos` and `g:hound_repo_paths`, and set:
+
+```vimscript
+let g:hound_preserve_repo_case = 1
+```
+
 This dictionary is required in order to use the `HoundQF` command.
 
 To ignore case in searches by default:

--- a/plugin/hound.vim
+++ b/plugin/hound.vim
@@ -26,6 +26,10 @@ if !exists('g:hound_vertical_split')
     let g:hound_vertical_split=0
 endif
 
+if !exists('g:hound_preserve_repo_case')
+    let g:hound_preserve_repo_case=0
+endif
+
 if !exists('g:hound_ignore_case')
     let g:hound_ignore_case=0
 endif
@@ -48,7 +52,11 @@ endfunction
 function! hound#fetchResults(query_string, clean_repos)
     let sanitized_query_string = hound#encodeUrl(a:query_string)
 
-    let clean_repos = substitute(g:hound_repos, " ","","g")
+    if g:hound_preserve_repo_case
+      let clean_repos = substitute(g:hound_repos, " ","","g")
+    else
+      let clean_repos = substitute(tolower(g:hound_repos), " ","","g")
+    endif
 
     let s:api_full_url = g:hound_base_url
                 \. ":" . g:hound_port
@@ -87,7 +95,11 @@ function! HoundQF(...) abort
         return
     endif
 
-    let clean_repos = substitute(join(keys(g:hound_repo_paths), ','), " ","","g")
+    if g:hound_preserve_repo_case
+      let clean_repos = substitute(join(keys(g:hound_repo_paths), ','), " ","","g")
+    else
+      let clean_repos = substitute(tolower(join(keys(g:hound_repo_paths), ',')), " ","","g")
+    endif
 
     try
         let response = hound#fetchResults(query_string, clean_repos)
@@ -128,7 +140,12 @@ endfunction
 function! Hound(...) abort
 
     let query_string = join(a:000)
-    let clean_repos = substitute(g:hound_repos, " ","","g")
+
+    if g:hound_preserve_repo_case
+      let clean_repos = substitute(g:hound_repos, " ","","g")
+    else
+      let clean_repos = substitute(tolower(g:hound_repos), " ","","g")
+    endif
 
     try
         let response = hound#fetchResults(query_string, clean_repos)

--- a/plugin/hound.vim
+++ b/plugin/hound.vim
@@ -48,7 +48,7 @@ endfunction
 function! hound#fetchResults(query_string, clean_repos)
     let sanitized_query_string = hound#encodeUrl(a:query_string)
 
-    let clean_repos = substitute(tolower(g:hound_repos), " ","","g")
+    let clean_repos = substitute(g:hound_repos, " ","","g")
 
     let s:api_full_url = g:hound_base_url
                 \. ":" . g:hound_port
@@ -87,7 +87,7 @@ function! HoundQF(...) abort
         return
     endif
 
-    let clean_repos = substitute(tolower(join(keys(g:hound_repo_paths), ',')), " ","","g")
+    let clean_repos = substitute(join(keys(g:hound_repo_paths), ','), " ","","g")
 
     try
         let response = hound#fetchResults(query_string, clean_repos)
@@ -128,7 +128,7 @@ endfunction
 function! Hound(...) abort
 
     let query_string = join(a:000)
-    let clean_repos = substitute(tolower(g:hound_repos), " ","","g")
+    let clean_repos = substitute(g:hound_repos, " ","","g")
 
     try
         let response = hound#fetchResults(query_string, clean_repos)


### PR DESCRIPTION
Hey Jeff!

Sometimes repos are labeled with capital letters, and so I needed a flag to allow me to specify that the case of my repos are being respected.  (I didn't want to change current behaviour, in case people were depending on it)

I'm running my fork right now and it works, but I figured other people might also be in this situation and benefit from this.

Hope things are going well across the pond!